### PR TITLE
refactor: rename UCAN -> Token

### DIFF
--- a/attenuation.go
+++ b/attenuation.go
@@ -36,10 +36,10 @@ LOOP:
 	return true
 }
 
-// AttenuationConstructor is a function that creates an attenuation from a map
+// AttenuationConstructorFunc is a function that creates an attenuation from a map
 // Users of this package provide an Attenuation Constructor to the parser to
 // bind attenuation logic to a UCAN
-type AttenuationConstructor func(v map[string]interface{}) (Attenuation, error)
+type AttenuationConstructorFunc func(v map[string]interface{}) (Attenuation, error)
 
 // Attenuation is a capability on a resource
 type Attenuation struct {

--- a/context.go
+++ b/context.go
@@ -8,19 +8,19 @@ import (
 // package
 type CtxKey string
 
-// UCANCtxKey is the key for adding an access UCAN to a context.Context
-const UCANCtxKey CtxKey = "UCAN"
+// TokenCtxKey is the key for adding an access UCAN to a context.Context
+const TokenCtxKey CtxKey = "UCAN"
 
-// CtxWithUCAN adds a UCAN value to a context
-func CtxWithUCAN(ctx context.Context, t UCAN) context.Context {
-	return context.WithValue(ctx, UCANCtxKey, t)
+// CtxWithToken adds a UCAN value to a context
+func CtxWithToken(ctx context.Context, t Token) context.Context {
+	return context.WithValue(ctx, TokenCtxKey, t)
 }
 
-// FromCtx extracts a Dataset reference from a given
-// context if one is set, returning nil otherwise
-func FromCtx(ctx context.Context) *UCAN {
-	iface := ctx.Value(UCANCtxKey)
-	if ref, ok := iface.(*UCAN); ok {
+// FromCtx extracts a token from a given context if one is set, returning nil
+// otherwise
+func FromCtx(ctx context.Context) *Token {
+	iface := ctx.Value(TokenCtxKey)
+	if ref, ok := iface.(*Token); ok {
 		return ref
 	}
 	return nil

--- a/example_test.go
+++ b/example_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/qri-io/ucan"
 )
 
-func ExampleWalkthrough() {
+func Example() {
 	source, err := ucan.NewPrivKeySource(keyOne)
 	panicIfError(err)
 
@@ -23,7 +23,7 @@ func ExampleWalkthrough() {
 	zero := time.Time{}
 
 	// create a root UCAN
-	origin, err := source.NewOriginUCAN(subjectDID, att, nil, zero, zero)
+	origin, err := source.NewOriginToken(subjectDID, att, nil, zero, zero)
 	panicIfError(err)
 
 	id, err := origin.CID()
@@ -35,7 +35,7 @@ func ExampleWalkthrough() {
 		{caps.Cap("SUPER_USER"), ucan.NewStringLengthResource("dataset", "third:resource")},
 	}
 
-	if _, err = source.NewAttenuatedUCAN(origin, subjectDID, att, nil, zero, zero); err != nil {
+	if _, err = source.NewAttenuatedToken(origin, subjectDID, att, nil, zero, zero); err != nil {
 		fmt.Println(err)
 	}
 
@@ -43,7 +43,7 @@ func ExampleWalkthrough() {
 		{caps.Cap("OVERWRITE"), ucan.NewStringLengthResource("dataset", "b5:world_bank_population:*")},
 	}
 
-	derivedToken, err := source.NewAttenuatedUCAN(origin, subjectDID, att, nil, zero, zero)
+	derivedToken, err := source.NewAttenuatedToken(origin, subjectDID, att, nil, zero, zero)
 	panicIfError(err)
 
 	id, err = derivedToken.CID()
@@ -67,7 +67,7 @@ func panicIfError(err error) {
 	}
 }
 
-func exampleParser() *ucan.UCANParser {
+func exampleParser() *ucan.TokenParser {
 	caps := ucan.NewNestedCapabilities("SUPER_USER", "OVERWRITE", "SOFT_DELETE", "REVISE", "CREATE")
 
 	ac := func(m map[string]interface{}) (ucan.Attenuation, error) {
@@ -95,5 +95,5 @@ func exampleParser() *ucan.UCANParser {
 	}
 
 	store := ucan.NewMemTokenStore()
-	return ucan.NewUCANParser(ac, ucan.StringDIDPubKeyResolver{}, store.(ucan.CIDBytesResolver))
+	return ucan.NewTokenParser(ac, ucan.StringDIDPubKeyResolver{}, store.(ucan.CIDBytesResolver))
 }

--- a/token_test.go
+++ b/token_test.go
@@ -57,7 +57,7 @@ func TestPrivKeySource(t *testing.T) {
 	}
 	zero := time.Time{}
 
-	root, err := source.NewOriginUCAN(didStr, att, nil, zero, zero)
+	root, err := source.NewOriginToken(didStr, att, nil, zero, zero)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +71,7 @@ func TestPrivKeySource(t *testing.T) {
 		{caps.Cap("OVERWRITE"), ucan.NewStringLengthResource("dataset", "b5:world_bank_population:*")},
 	}
 
-	derivedToken, err := source.NewAttenuatedUCAN(root, didStr, att, nil, zero, zero)
+	derivedToken, err := source.NewAttenuatedToken(root, didStr, att, nil, zero, zero)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,14 +130,14 @@ func TestTokenParse(t *testing.T) {
 	}
 
 	store := ucan.NewMemTokenStore()
-	p := ucan.NewUCANParser(ac, ucan.StringDIDPubKeyResolver{}, store.(ucan.CIDBytesResolver))
+	p := ucan.NewTokenParser(ac, ucan.StringDIDPubKeyResolver{}, store.(ucan.CIDBytesResolver))
 	_, err := p.ParseAndVerify(context.Background(), raw)
 	if err != nil {
 		t.Error(err)
 	}
 }
 
-func mustCidString(t *testing.T, tok *ucan.UCAN) string {
+func mustCidString(t *testing.T, tok *ucan.Token) string {
 	t.Helper()
 	id, err := tok.CID()
 	if err != nil {


### PR DESCRIPTION
When using this package, `ucan.Token` reads better than `ucan.UCAN` to me.
Encourages the reader to think in terms of "tokens", from the "ucan" package.

Performed this refactoring with a  few commands (and a few comment edits):
```
  $ gofmt -r 'UCAN -> Token' -w .
  $ gofmt -r 'NewAttenuatedUCAN -> NewAttenuatedToken' -w .
  $ gofmt -r 'NewOriginUCAN -> NewOriginToken' -w .
  $ gofmt -r 'UCANParser -> TokenParser' -w .
  $ gofmt -r 'NewUCANParser -> NewTokenParser' -w .
  $ gofmt -r 'UCANCtxKey -> TokenCtxKey' -w .
```
spf13 has a great [blog post](https://spf13.com/post/go-fmt/) on using gofmt to refactor. (cc @ramfox & @Arqu for this trick)

Changed example test "ExampleWalkthrough" to "Example" to make go vet happy
